### PR TITLE
Enable the ability to run just once

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ func run(cmd *cobra.Command, args []string) error {
 	app := app.NewApp(circleToken, vaultTokenFile, tfCloudToken, config, enableMetrics)
 
 	if runOnce {
+		app.EnableMetrics = false
 		return app.RunOnce()
 	}
 	return app.Run()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,6 +34,7 @@ var (
 	tfCloudToken   string
 	vaultTokenFile string
 	enableMetrics  bool
+	runOnce        bool
 )
 
 var rootCmd = &cobra.Command{
@@ -52,6 +53,9 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	app := app.NewApp(circleToken, vaultTokenFile, tfCloudToken, config, enableMetrics)
 
+	if runOnce {
+		return app.RunOnce()
+	}
 	return app.Run()
 }
 
@@ -71,6 +75,7 @@ func init() {
 	rootCmd.Flags().StringVar(&tfCloudToken, "tfcloud-token", "", "A token for TFCloud access.")
 	rootCmd.Flags().StringVar(&vaultTokenFile, "vault-token-file", "", "A file that contains a vault token. Optional - can set VAULT_TOKEN directly if preferred.")
 	rootCmd.Flags().BoolVar(&enableMetrics, "enable-metrics", true, "Enable a prometheus endpoint on port 4329.")
+	rootCmd.Flags().BoolVar(&runOnce, "run-once", false, "If true, will run the token injection one time. Does not enable health endpoint or metrics.")
 
 	envMap := map[string]string{
 		"CIRCLE_CI_TOKEN":  "circle-token",

--- a/pkg/app/errors.go
+++ b/pkg/app/errors.go
@@ -44,16 +44,22 @@ func (a *App) registerMetrics() {
 }
 
 func (a App) incrementVaultError() {
-	a.Metrics.vaultErrorCount.Inc()
-	a.Metrics.totalErrorCount.Inc()
+	if a.EnableMetrics {
+		a.Metrics.vaultErrorCount.Inc()
+		a.Metrics.totalErrorCount.Inc()
+	}
 }
 
 func (a App) incrementTfCloudError() {
-	a.Metrics.tfCloudErrorCount.Inc()
-	a.Metrics.totalErrorCount.Inc()
+	if a.EnableMetrics {
+		a.Metrics.tfCloudErrorCount.Inc()
+		a.Metrics.totalErrorCount.Inc()
+	}
 }
 
 func (a App) incrementCircleCIError() {
-	a.Metrics.circleCIErrorCount.Inc()
-	a.Metrics.totalErrorCount.Inc()
+	if a.EnableMetrics {
+		a.Metrics.circleCIErrorCount.Inc()
+		a.Metrics.totalErrorCount.Inc()
+	}
 }


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
We may want to run this as a cronjob, rather than a long-lived deployment. In that case, we will want to skip the loop and prometheus endpoint and just run once.

### What changes did you make?
Added a flag to --run-once

### What alternative solution should we consider, if any?
none that I can think of