### PR TITLE
Return an error if the run-once has any errors

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -167,6 +167,10 @@ func (a *App) RunOnce() error {
 		go a.updateCircleCIInstance(project, &wg)
 	}
 	wg.Wait()
+	errCount := getMetricValue(a.Metrics.totalErrorCount)
+	if errCount > 0 {
+		return fmt.Errorf("there were errors during during the run. see the logs for more details")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
If --run-once encounters any errors, it should exit non-zero now